### PR TITLE
Parse stream of data from STDIN

### DIFF
--- a/packages/steamdown/src/bin.ts
+++ b/packages/steamdown/src/bin.ts
@@ -8,11 +8,7 @@ if (inputArg && inputArg !== '-') {
   const input = readFileSync(inputArg, 'utf8');
   console.log(parse(input));
 } else {
-  const readline = createInterface({
-    input: process.stdin,
-  });
-
-  readline.on('line', (line) => {
-    console.log(parse(line));
+  process.stdin.on('data', (data) => {
+    console.log(parse(data.toString()));
   });
 }


### PR DESCRIPTION
This allows for multiline inputs from STDIN by reading data instead of
lines, fixing how the binary parses block-level syntax like code blocks.

Fixes #3
