### PR TITLE
Simplify spoiler regex

### DIFF
--- a/packages/steamdown/__tests__/main.test.ts
+++ b/packages/steamdown/__tests__/main.test.ts
@@ -38,11 +38,6 @@ describe("formatting", () => {
     test("exclamation outside of spoiler", () => {
       expect(parse("!!!spoiler text!!!\\!")).toBe("[spoiler]spoiler text[/spoiler]!");
     });
-    test("spoiler with newlines", () => {
-      expect(parse("!!!spoiler\nthis\ntext!!!")).toBe(
-        "[spoiler]spoiler\nthis\ntext[/spoiler]",
-      );
-    });
   });
 
   describe("Literal text", () => {

--- a/packages/steamdown/src/extensions.ts
+++ b/packages/steamdown/src/extensions.ts
@@ -69,7 +69,7 @@ const spoiler: Extension = {
     return src.match(/!!!/)?.index as number;
   },
   tokenizer(src: string): SpoilerToken | void {
-    const match = src.match(/^!!!((?:.+\n|.*)*[^\n])!!!/);
+    const match = src.match(/^!!!([^\n]*)!!!/);
     if (match) {
       return {
         type: "spoiler",


### PR DESCRIPTION
This fixes an issue where trailing characters after the spoiler would
severely effect performance.

Fixes #123
