### PR TITLE
Fix nested asterisks

### DIFF
--- a/packages/steamdown/__tests__/steamdown.test.js
+++ b/packages/steamdown/__tests__/steamdown.test.js
@@ -13,6 +13,8 @@ describe("steamdown", () => {
     ["bold ending in italics (#233)", "**bold ending in *italics***", "[b]bold ending in [i]italics[/i][/b]"],
     ["bold beginning with italics (#233)", "***italics* and bold**", "[b][i]italics[/i] and bold[/b]"],
     ["italics containing bold (#233)", "*italics **bold** italics*", "[i]italics [b]bold[/b] italics[/i]"],
+    ["italics ending in italics {#233)", "*italics ending in **bold***", "[i]italics ending in [b]bold[/b][/i]"],
+    ["italics beginning with bold (#233)", "***bold** and italics*", "[i][b]bold[/b] and italics[/i]"],
   ])("%s", (_name, input, expected) => {
     const { tree, context } = parse(input);
     const rendered = render(tree, context);

--- a/packages/steamdown/__tests__/steamdown.test.js
+++ b/packages/steamdown/__tests__/steamdown.test.js
@@ -8,4 +8,13 @@ describe("steamdown", () => {
     const rendered = render(tree, context);
     expect(rendered).toMatchSnapshot();
   });
+
+  test.each([
+    ["bold ending in italics (#233)", "**bold ending in *italics***", "[b]bold ending in [i]italics[/i][/b]"],
+    ["bold beginning with italics (#233)", "***italics* and bold**", "[b][i]italics[/i] and bold[/b]"],
+  ])("%s", (_name, input, expected) => {
+    const { tree, context } = parse(input);
+    const rendered = render(tree, context);
+    expect(rendered).toBe(expected);
+  });
 });

--- a/packages/steamdown/__tests__/steamdown.test.js
+++ b/packages/steamdown/__tests__/steamdown.test.js
@@ -12,6 +12,7 @@ describe("steamdown", () => {
   test.each([
     ["bold ending in italics (#233)", "**bold ending in *italics***", "[b]bold ending in [i]italics[/i][/b]"],
     ["bold beginning with italics (#233)", "***italics* and bold**", "[b][i]italics[/i] and bold[/b]"],
+    ["italics containing bold (#233)", "*italics **bold** italics*", "[i]italics [b]bold[/b] italics[/i]"],
   ])("%s", (_name, input, expected) => {
     const { tree, context } = parse(input);
     const rendered = render(tree, context);

--- a/packages/steamdown/src/parser/inline/bold.ts
+++ b/packages/steamdown/src/parser/inline/bold.ts
@@ -1,11 +1,53 @@
 import type * as nodes from "../../nodes";
 import type { Parser } from "../types";
+import { ParseError, UnreachableError } from "../errors";
 import { makeWrappedTextParser } from "./util.js";
+import { parse } from "./parse";
 
 /**
  * Parser for a bold node.
  */
-export const bold = makeWrappedTextParser<nodes.Bold>(
-  "**",
-  "bold",
-) satisfies Parser<nodes.Bold>;
+export const bold = {
+  hint: (text: string) => text.startsWith("**"),
+  parse: (text: string): [nodes.Bold, remainder: string] => {
+    text = text.slice(2);
+    let searchIndex = 0;
+    const italicsStartRe = /(?<!\\)\*[^\s\*]/g;
+
+    // HACK Handle nested italics (**foo *bar* baz** and **foo *bar***). We do a simple
+    //      search for italics beginning and end markers, and skip over them.
+    while (true) {
+      const italicsStart = italicsStartRe.exec(text);
+      if (!italicsStart) {
+        break;
+      }
+      const italicsEndRe = /(?<!\\|\s)\*/g;
+      italicsEndRe.lastIndex = italicsStart.index + 1;
+      const italicsEnd = italicsEndRe.exec(text);
+      if (!italicsEnd) {
+        break;
+      }
+      searchIndex = italicsEnd.index + 1;
+      italicsStartRe.lastIndex = searchIndex;
+    }
+
+    const endRe = /(?<!\\|\s)\*\*/g;
+    endRe.lastIndex = searchIndex;
+    const endMatch = endRe.exec(text);
+    if (!endMatch) {
+      throw new ParseError("bold must be closed");
+    }
+
+    const innerText = text.slice(0, endMatch.index);
+    const remainder = text.slice(endMatch.index + 2);
+
+    const nodes = parse(innerText);
+
+    const node: nodes.Bold = {
+      type: "bold",
+      nodes,
+    };
+
+    return [node, remainder];
+  },
+} satisfies Parser<nodes.Bold>;

--- a/packages/steamdown/src/parser/inline/italics.ts
+++ b/packages/steamdown/src/parser/inline/italics.ts
@@ -1,11 +1,35 @@
 import type * as nodes from "../../nodes";
 import type { Parser } from "../types";
+import { ParseError, UnreachableError } from "../errors";
 import { makeWrappedTextParser } from "./util.js";
+import { parse } from "./parse";
 
 /**
  * Parser for an italics node.
  */
-export const italics = makeWrappedTextParser<nodes.Italics>(
-  "*",
-  "italics",
-) satisfies Parser<nodes.Italics>;
+export const italics = {
+  hint: (text: string) => text.startsWith("*"),
+  parse: (text: string): [nodes.Italics, remainder: string] => {
+    text = text.slice(1);
+
+    // NOTE This might invalidate the text "*foo**", which could be considered as
+    //      italicized "foo" followed by "*". Supporting this malformed text is not a
+    //      priority, and the user can escape the trailing "*" to avoid this.
+    const close = /(?<!\\|\s|[^\\]\*)\*(?!\*)/.exec(text);
+    if (!close) {
+      throw new ParseError("italics must be closed");
+    }
+
+    const innerText = text.slice(0, close.index);
+    const remainder = text.slice(close.index + 1);
+
+    const nodes = parse(innerText);
+
+    const node: nodes.Italics = {
+      type: "italics",
+      nodes,
+    };
+
+    return [node, remainder];
+  },
+} satisfies Parser<nodes.Italics>;


### PR DESCRIPTION
# to do

- [x] Fix `*foo **bar***` (probably broken by https://github.com/spenserblack/steamdown/pull/244/commits/a3fb3c95d910a9169574a02134bfe057da77bc4c)
- [x] Fix `***foo** bar*`

These 4 combos should be tested:

| text | expected |
| :--: | :------: |
| `***foo* bar**` | `[b][i]foo[/i] bar[/b]` |
| `***foo** bar*` | `[i][b]foo[/b] bar[/i]` |
| `**foo *bar***` | `[b]foo [i]bar[/i][/b]` |
| `*foo **bar***` | `[i]foo [b]bar[/b][/i]` |