### PR TITLE
Use double underscores for underlines

### DIFF
--- a/packages/html/__tests__/demo.stmd
+++ b/packages/html/__tests__/demo.stmd
@@ -20,10 +20,10 @@ Syntax includes:
 * *italics*
 * **bold**
 * ***bold and italics***
-* _underlines_
+* __underlines__
 * >!spoilers!<
 * ~~strike outs~~
-* *_you can mix and match BTW_*
+* *__you can mix and match BTW__*
 * {noparse spans are literal. *this won't be rendered* and Steam will show literal [i]}
 
 {{{

--- a/packages/site/src/demo.stmd
+++ b/packages/site/src/demo.stmd
@@ -11,7 +11,7 @@ Inline styling includes:
 
 * *italics*
 * **bold**
-* _underline_
+* __underline__
 * >!spoiler!<
 * ~~strikes~~
 * {noparse}

--- a/packages/steamdown/__tests__/assets/demo.test.txt
+++ b/packages/steamdown/__tests__/assets/demo.test.txt
@@ -20,10 +20,10 @@ Syntax includes:
 * *italics*
 * **bold**
 * ***bold and italics***
-* _underlines_
+* __underlines__
 * >!spoilers!<
 * ~~strike outs~~
-* *_you can mix and match BTW_*
+* *__you can mix and match BTW__*
 * {noparse spans are literal. *this won't be rendered* and Steam will show literal [i]}
 
 {{{

--- a/packages/steamdown/__tests__/assets/underlined in italicized.test.txt
+++ b/packages/steamdown/__tests__/assets/underlined in italicized.test.txt
@@ -1,1 +1,1 @@
-*Italicized and _underlined_*
+*Italicized and __underlined__*

--- a/packages/steamdown/__tests__/assets/underlined.test.txt
+++ b/packages/steamdown/__tests__/assets/underlined.test.txt
@@ -1,1 +1,1 @@
-_Underlined text_
+__Underlined text__

--- a/packages/steamdown/__tests__/feedback.test.js
+++ b/packages/steamdown/__tests__/feedback.test.js
@@ -8,6 +8,10 @@ const { parse, render } = require("../dist");
 const feedback = [
   // Example
   ["Example", "*Hello, World!*", "[i]Hello, World![/i]"],
+  [291, "![Wikipedia](https://example.com/example.jpg)", "[img]https://example.com/example.jpg[/img]"],
+  [291, "[![Wikipedia](https://example.com/example.jpg)](https://example.com/example.jpg)", "[url=https://example.com/example.jpg][img]https://example.com/example.jpg[/img][/url]"],
+  [293, "test_underscore_test", "test_underscore_test"],
+  [293, "underscore_test_", "underscore_test_"],
 ];
 
 // -------------------------------------------------------------------------------------

--- a/packages/steamdown/src/parser/inline/underline.ts
+++ b/packages/steamdown/src/parser/inline/underline.ts
@@ -6,6 +6,6 @@ import { makeWrappedTextParser } from "./util.js";
  * Parser for an underline node.
  */
 export const underline = makeWrappedTextParser<nodes.Underline>(
-  "_",
+  "__",
   "underline",
 ) satisfies Parser<nodes.Underline>;


### PR DESCRIPTION
This changes underscore syntax to require two underscores (`__`) to 
wrap text. 

One of the benefits of this is that underscores in words, like a URL or 
some type of slug-like string, will not be treated as special syntax, 
being removed and converted to underlines. Underscores are pretty common
in Steam URLs, so this can be especially annoying.

If Steam allows double underscores in its URLs, and its fairly common,
this might need to be revisited.

This also addresses #247.

Closes #247
