### PR TITLE
Remove try-catch branching

### DIFF
--- a/packages/steamdown/src/parser/block/code.ts
+++ b/packages/steamdown/src/parser/block/code.ts
@@ -1,5 +1,5 @@
 import type * as nodes from "../../nodes";
-import { UnreachableError, ParseError } from "../errors.js";
+import { UnreachableError } from "../errors.js";
 import type { Parser } from "../types";
 import { Memoizer } from "../util.js";
 import escapeRegExp from "escape-string-regexp";
@@ -11,7 +11,7 @@ const memo = new Memoizer<string, RegExp>();
  */
 export const code = {
   hint: (text: string) => /^`{3,}[^`\r\n]*\r?\n/.test(text),
-  parse: (text: string): [nodes.CodeBlock, remainder: string] => {
+  parse: (text: string): [nodes.CodeBlock, remainder: string] | null => {
     const open = /^(`{3,})[^`\r\n]*\r?\n/.exec(text);
     if (!open) {
       throw new UnreachableError();
@@ -27,7 +27,7 @@ export const code = {
       .exec(text);
 
     if (!close) {
-      throw new ParseError("code block must be closed");
+      return null;
     }
 
     const closeIndex = close.index;

--- a/packages/steamdown/src/parser/block/heading.ts
+++ b/packages/steamdown/src/parser/block/heading.ts
@@ -1,5 +1,4 @@
 import type * as nodes from "../../nodes";
-import { ParseError } from "../errors.js";
 import { parse as parseInline } from "../inline/index.js";
 import type { Parser } from "../types";
 
@@ -8,11 +7,11 @@ import type { Parser } from "../types";
  */
 export const heading = {
   hint: (text: string) => text.startsWith("#"),
-  parse: (text: string): [nodes.Heading, remainder: string] => {
+  parse: (text: string): [nodes.Heading, remainder: string] | null => {
     const match = /^(#{1,6})\s(.+)(?:(?:\r?\n){1,2}|$)/.exec(text);
 
     if (!match) {
-      throw new ParseError("Invalid heading");
+      return null;
     }
 
     const headingText = match[2];
@@ -45,11 +44,11 @@ export const heading = {
  */
 export const altHeading = {
   hint: (text: string) => /^.+\r?\n(?:===+|---+)/.test(text),
-  parse: (text: string): [nodes.Heading, remainder: string] => {
+  parse: (text: string): [nodes.Heading, remainder: string] | null => {
     const match = /^(.+)\r?\n(===+|---+)(?:(?:\r?\n){1,2}|$)/.exec(text);
 
     if (!match) {
-      throw new ParseError("Invalid heading");
+      return null;
     }
 
     const headingText = match[1];

--- a/packages/steamdown/src/parser/block/horizontal-rule.ts
+++ b/packages/steamdown/src/parser/block/horizontal-rule.ts
@@ -1,5 +1,4 @@
 import type * as nodes from "../../nodes";
-import { ParseError } from "../errors.js";
 import type { Parser } from "../types";
 
 /**
@@ -7,11 +6,11 @@ import type { Parser } from "../types";
  */
 export const horizontalRule = {
   hint: (text: string) => ["---", "***", "___"].some((rule) => text.startsWith(rule)),
-  parse: (text: string): [nodes.HorizontalRule, remainder: string] => {
+  parse: (text: string): [nodes.HorizontalRule, remainder: string] | null => {
     const match = /^(?:---+|___+|\*\*\*+)(?:(?:\r?\n)+|$)/.exec(text);
 
     if (!match) {
-      throw new ParseError("Invalid horizontal rule");
+      return null;
     }
 
     const remainder = text.slice(match[0].length);

--- a/packages/steamdown/src/parser/block/noparse.ts
+++ b/packages/steamdown/src/parser/block/noparse.ts
@@ -1,5 +1,5 @@
 import type * as nodes from "../../nodes";
-import { UnreachableError, ParseError } from "../errors.js";
+import { UnreachableError } from "../errors.js";
 import type { Parser } from "../types";
 import { Memoizer } from "../util.js";
 import escapeRegExp from "escape-string-regexp";
@@ -11,7 +11,7 @@ const memo = new Memoizer<string, RegExp>();
  */
 export const noparse = {
   hint: (text: string) => /^{{{+\r?\n/.test(text),
-  parse: (text: string): [nodes.NoparseBlock, remainder: string] => {
+  parse: (text: string): [nodes.NoparseBlock, remainder: string] | null => {
     const open = /^({{{+)\r?\n/.exec(text);
     if (!open) {
       throw new UnreachableError();
@@ -27,7 +27,7 @@ export const noparse = {
       .exec(text);
 
     if (!close) {
-      throw new ParseError("noparse block must be closed");
+      return null;
     }
 
     const closeIndex = close.index;

--- a/packages/steamdown/src/parser/block/reference.ts
+++ b/packages/steamdown/src/parser/block/reference.ts
@@ -1,5 +1,4 @@
 import type * as nodes from "../../nodes";
-import { ParseError } from "../errors.js";
 import type { Parser } from "../types";
 
 /**
@@ -7,11 +6,11 @@ import type { Parser } from "../types";
  */
 export const reference = {
   hint: (text: string) => text.startsWith("["),
-  parse: (text: string): [nodes.Reference, remainder: string] => {
+  parse: (text: string): [nodes.Reference, remainder: string] | null => {
     const match = /^\[((?:[^\]]|\\\])+)(?<!\\)\]:\s+(.+)(?:\r?\n)*/.exec(text);
 
     if (!match) {
-      throw new ParseError("invalid reference");
+      return null;
     }
 
     const [all, id, url] = match;

--- a/packages/steamdown/src/parser/block/table.ts
+++ b/packages/steamdown/src/parser/block/table.ts
@@ -1,5 +1,5 @@
 import type * as nodes from "../../nodes";
-import { ParseError, UnreachableError } from "../errors.js";
+import { UnreachableError } from "../errors.js";
 import { parse as parseInline } from "../inline/index.js";
 import type { Parser } from "../types";
 
@@ -21,17 +21,17 @@ type TablePart = HeadSym | AttributesSym | BodySym;
 function parseTableRow(
   text: string,
   part: AttributesSym,
-): [nodes.TableAttributeRow, remainder: string];
+): [nodes.TableAttributeRow, remainder: string] | null;
 function parseTableRow(
   text: string,
   part: Exclude<TablePart, AttributesSym>,
-): [nodes.TableRow, remainder: string];
+): [nodes.TableRow, remainder: string] | null;
 function parseTableRow(
   text: string,
   part: TablePart,
-): [nodes.TableRow | nodes.TableAttributeRow, remainder: string] {
+): [nodes.TableRow | nodes.TableAttributeRow, remainder: string] | null {
   if (text == "" || /^\r?\n/.test(text)) {
-    throw new ParseError("Empty table row");
+    return null;
   }
 
   const endLine = /$/m.exec(text)?.index;
@@ -42,7 +42,7 @@ function parseTableRow(
 
   let line = text.slice(0, endLine);
   if (!line.includes("|")) {
-    throw new ParseError("Invalid table row");
+    return null;
   }
   // NOTE If the user didn't add `|` to the beginning or end of the row, we add it.
   if (!line.startsWith("|")) {
@@ -64,7 +64,7 @@ function parseTableRow(
       (cell) => borderedAttrRe.test(cell) || borderlessAttrRe.test(cell),
     )
   ) {
-    throw new ParseError("Invalid table attributes");
+    return null;
   }
 
   text = text.slice(endLine);
@@ -93,26 +93,29 @@ function parseTableRow(
  */
 export const table = {
   hint: (text: string) => /^\|[^\n|]/.test(text),
-  parse: (text: string): [nodes.Table, remainder: string] => {
+  parse: (text: string): [nodes.Table, remainder: string] | null => {
     const headMatch = parseTableRow(text, head);
+    if (headMatch == null) {
+      return null;
+    }
     const tHead = headMatch[0];
     text = headMatch[1];
     const attributesMatch = parseTableRow(text, attributes);
+    if (attributesMatch == null) {
+      return null;
+    }
     const tAttributes = attributesMatch[0];
     text = attributesMatch[1];
 
     const tBody: nodes.TableRow[] = [];
     while (true) {
-      try {
-        const [row, remainder] = parseTableRow(text, body);
-        text = remainder;
-        tBody.push(row);
-      } catch (e) {
-        if (e instanceof ParseError) {
-          break;
-        }
-        throw e;
+      const parsed = parseTableRow(text, body);
+      if (parsed == null) {
+        break;
       }
+      const [row, remainder] = parsed;
+      text = remainder;
+      tBody.push(row);
     }
 
     const node: nodes.Table = {

--- a/packages/steamdown/src/parser/errors.ts
+++ b/packages/steamdown/src/parser/errors.ts
@@ -1,5 +1,3 @@
-export class ParseError extends Error {}
-
 export class UnreachableError extends Error {
   constructor(msg?: string) {
     super(msg ?? "Unreachable");

--- a/packages/steamdown/src/parser/inline/bold.ts
+++ b/packages/steamdown/src/parser/inline/bold.ts
@@ -1,6 +1,5 @@
 import type * as nodes from "../../nodes";
 import type { Parser } from "../types";
-import { ParseError } from "../errors.js";
 import { parse } from "./parse.js";
 
 /**
@@ -8,7 +7,7 @@ import { parse } from "./parse.js";
  */
 export const bold = {
   hint: (text: string) => text.startsWith("**"),
-  parse: (text: string): [nodes.Bold, remainder: string] => {
+  parse: (text: string): [nodes.Bold, remainder: string] | null => {
     text = text.slice(2);
     let searchIndex = 0;
     const italicsStartRe = /(?<!\\)\*[^\s*]/g;
@@ -34,7 +33,7 @@ export const bold = {
     endRe.lastIndex = searchIndex;
     const endMatch = endRe.exec(text);
     if (!endMatch) {
-      throw new ParseError("bold must be closed");
+      return null;
     }
 
     const innerText = text.slice(0, endMatch.index);

--- a/packages/steamdown/src/parser/inline/escaped.ts
+++ b/packages/steamdown/src/parser/inline/escaped.ts
@@ -1,5 +1,4 @@
 import type * as nodes from "../../nodes";
-import { ParseError } from "../errors.js";
 import type { Parser } from "../types";
 
 const escapable = new Set([
@@ -21,10 +20,10 @@ const escapable = new Set([
  */
 export const escaped = {
   hint: (text: string) => text.startsWith("\\"),
-  parse: (text: string): [nodes.Escaped, remainder: string] => {
+  parse: (text: string): [nodes.Escaped, remainder: string] | null => {
     const nextChar = text[1];
     if (!escapable.has(nextChar)) {
-      throw new ParseError(`cannot escape ${nextChar}`);
+      return null;
     }
     const node: nodes.Escaped = {
       type: "escaped",

--- a/packages/steamdown/src/parser/inline/image.ts
+++ b/packages/steamdown/src/parser/inline/image.ts
@@ -7,9 +7,13 @@ import { url as urlParser } from "./url.js";
  */
 export const image = {
   hint: (text: string) => text.startsWith("!["),
-  parse: (text: string): [nodes.Image, remainder: string] => {
+  parse: (text: string): [nodes.Image, remainder: string] | null => {
     text = text.slice(1);
-    const [url, remainder] = urlParser.parse(text);
+    const parsed = urlParser.parse(text);
+    if (parsed == null) {
+      return null;
+    }
+    const [url, remainder] = parsed;
     const node: nodes.Image = {
       type: "image",
       url,

--- a/packages/steamdown/src/parser/inline/italics.ts
+++ b/packages/steamdown/src/parser/inline/italics.ts
@@ -1,6 +1,5 @@
 import type * as nodes from "../../nodes";
 import type { Parser } from "../types";
-import { ParseError } from "../errors.js";
 import { parse } from "./parse.js";
 
 /**
@@ -8,7 +7,7 @@ import { parse } from "./parse.js";
  */
 export const italics = {
   hint: (text: string) => text.startsWith("*"),
-  parse: (text: string): [nodes.Italics, remainder: string] => {
+  parse: (text: string): [nodes.Italics, remainder: string] | null => {
     text = text.slice(1);
     let searchIndex = 0;
     const boldStartRe = /(?<!\\)\*\*/g;
@@ -35,7 +34,7 @@ export const italics = {
     endRe.lastIndex = searchIndex;
     const endMatch = endRe.exec(text);
     if (!endMatch) {
-      throw new ParseError("italics must be closed");
+      return null;
     }
 
     const innerText = text.slice(0, endMatch.index);

--- a/packages/steamdown/src/parser/inline/noparse.ts
+++ b/packages/steamdown/src/parser/inline/noparse.ts
@@ -1,5 +1,5 @@
 import type * as nodes from "../../nodes";
-import { UnreachableError, ParseError } from "../errors.js";
+import { UnreachableError } from "../errors.js";
 import escapeRegExp from "escape-string-regexp";
 import type { Parser } from "../types";
 
@@ -8,7 +8,7 @@ import type { Parser } from "../types";
  */
 export const noparse = {
   hint: (text: string) => text.startsWith("{"),
-  parse: (text: string): [nodes.NoparseSpan, remainder: string] => {
+  parse: (text: string): [nodes.NoparseSpan, remainder: string] | null => {
     const openingMatch = /^\{+/.exec(text);
 
     if (!openingMatch) {
@@ -19,7 +19,7 @@ export const noparse = {
 
     const closingIndex = closing.exec(text)?.index;
     if (closingIndex == null) {
-      throw new ParseError("noparse span must be closed");
+      return null;
     }
 
     let innerText = text.slice(opening.length, closingIndex);

--- a/packages/steamdown/src/parser/inline/strike.ts
+++ b/packages/steamdown/src/parser/inline/strike.ts
@@ -1,5 +1,4 @@
 import type * as nodes from "../../nodes";
-import { ParseError } from "../errors.js";
 import type { Parser } from "../types";
 import { variableLengthInlineHelper } from "./util.js";
 import { parse } from "./parse.js";
@@ -11,18 +10,15 @@ const helper = variableLengthInlineHelper("~");
  */
 export const strike = {
   hint: (text: string) => text.startsWith("~"),
-  parse: (text: string): [nodes.Strike, remainder: string] => {
+  parse: (text: string): [nodes.Strike, remainder: string] | null => {
     const result = helper(text);
-    switch (result) {
-      case "no match":
-        throw new ParseError("strike must start with ~");
-      case "not closed":
-        throw new ParseError("strike must be closed");
+    if (result == null) {
+      return null;
     }
     const { wrapper, text: innerText } = result;
     const consumedCharCount = wrapper.length + innerText.length + wrapper.length;
     if ([innerText[0], innerText[innerText.length - 1]].some((s) => /\s/.test(s))) {
-      throw new ParseError("strike cannot start or end with whitespace");
+      return null;
     }
     const nodes = parse(innerText);
 

--- a/packages/steamdown/src/parser/inline/url.ts
+++ b/packages/steamdown/src/parser/inline/url.ts
@@ -1,5 +1,4 @@
 import type * as nodes from "../../nodes";
-import { ParseError } from "../errors.js";
 import type { Parser } from "../types";
 import { parse } from "./parse.js";
 
@@ -7,7 +6,7 @@ import { parse } from "./parse.js";
  * Extracts the `TEXT` from `[TEXT](LINK)` or `[TEXT][ID]`. `text` should always
  * start with `[`.
  */
-const extractText = (text: string): [text: string, remainder: string] => {
+const extractText = (text: string): [text: string, remainder: string] | null => {
   // NOTE We're assuming that the text matches the hint.
   let opened = 1;
   for (let index = 1; index < text.length; index++) {
@@ -24,7 +23,7 @@ const extractText = (text: string): [text: string, remainder: string] => {
       return [text.slice(1, index), remainder];
     }
   }
-  throw new ParseError("invalid url text");
+  return null;
 };
 
 /**
@@ -32,15 +31,18 @@ const extractText = (text: string): [text: string, remainder: string] => {
  */
 export const url = {
   hint: (text: string) => text.startsWith("["),
-  parse: (text: string): [nodes.Url, remainder: string] => {
+  parse: (text: string): [nodes.Url, remainder: string] | null => {
     const extractedText = extractText(text);
+    if (extractedText == null) {
+      return null;
+    }
     const content = extractedText[0];
     text = extractedText[1];
     // TODO Break this up into something more readable.
     const match = /^(?:(?:\(([^)\n]+)\))|\[((?:[^\]\n]|\\\])+)\])?/.exec(text);
 
     if (!match) {
-      throw new ParseError("invalid url");
+      return null;
     }
 
     const [all, link, id] = match;

--- a/packages/steamdown/src/parser/inline/util.ts
+++ b/packages/steamdown/src/parser/inline/util.ts
@@ -1,5 +1,5 @@
 import type * as nodes from "../../nodes";
-import { ParseError, UnreachableError } from "../errors.js";
+import { UnreachableError } from "../errors.js";
 import escapeRegExp from "escape-string-regexp";
 import { parse } from "./parse.js";
 
@@ -22,23 +22,23 @@ export const makeWrappedTextParser = <N extends WrappedNode>(
   const endRegex = new RegExp(`(?<!\\\\)${escapeRegExp(endWrapper)}`);
   return {
     hint: (text: string) => text.startsWith(startWrapper),
-    parse: (text: string): [N, remainder: string] => {
+    parse: (text: string): [N, remainder: string] | null => {
       text = text.slice(startWrapper.length);
 
       const endMatch = endRegex.exec(text);
       if (!endMatch) {
-        throw new ParseError(`${type} must be closed`);
+        return null;
       }
       const innerEndIndex = endMatch.index;
 
       const innerText = text.slice(0, endMatch.index);
 
       if (innerText.length === 0) {
-        throw new ParseError(`${type} must have content`);
+        return null;
       }
 
       if ([innerText[0], innerText[innerText.length - 1]].some((s) => /\s/.test(s))) {
-        throw new ParseError(`${type} cannot start or end with whitespace`);
+        return null;
       }
 
       const remainder = text.slice(innerEndIndex + endWrapper.length);
@@ -79,7 +79,7 @@ export const variableLengthInlineHelper = (wrapperChar: string) => {
   return (text: string) => {
     const wrapperMatch = regex.exec(text);
     if (!wrapperMatch) {
-      return "no match";
+      return null;
     }
     const wrapper = wrapperMatch[0];
     const endRegex = new RegExp(`(?<!\\\\)${escapeRegExp(wrapper)}`);
@@ -87,7 +87,7 @@ export const variableLengthInlineHelper = (wrapperChar: string) => {
     const endMatch = endRegex.exec(text);
 
     if (!endMatch) {
-      return "not closed";
+      return null;
     }
 
     text = text.slice(0, endMatch.index);

--- a/packages/steamdown/src/parser/types.ts
+++ b/packages/steamdown/src/parser/types.ts
@@ -15,7 +15,7 @@ export interface Parser<N extends nodes.Node> {
    * Parses the given syntax, returning the root node of the
    * syntax tree and the remaining text. Can optionally mutate context.
    */
-  parse(text: string): [node: N, remainder: string];
+  parse(text: string): [node: N, remainder: string] | null;
 }
 
 export type InlineParser = Parser<nodes.Inline>;

--- a/packages/steamdown/src/parser/util.ts
+++ b/packages/steamdown/src/parser/util.ts
@@ -10,7 +10,10 @@ export const firstSuccessfulParse = <N extends nodes.Node>(
 ): [N, remainder: string] | null => {
   for (const parser of parsers) {
     if (parser.hint(text)) {
-      return parser.parse(text);
+      const result = parser.parse(text);
+      if (result) {
+        return result;
+      }
     }
   }
   return null;

--- a/packages/steamdown/src/parser/util.ts
+++ b/packages/steamdown/src/parser/util.ts
@@ -1,6 +1,5 @@
 import type * as nodes from "../nodes";
 import type { Parser } from "./types";
-import { ParseError } from "./errors.js";
 
 /**
  * Returns the first successful parse from the given parsers.
@@ -11,13 +10,7 @@ export const firstSuccessfulParse = <N extends nodes.Node>(
 ): [N, remainder: string] | null => {
   for (const parser of parsers) {
     if (parser.hint(text)) {
-      try {
-        return parser.parse(text);
-      } catch (error) {
-        if (!(error instanceof ParseError)) {
-          throw error;
-        }
-      }
+      return parser.parse(text);
     }
   }
   return null;


### PR DESCRIPTION
Instead of relying on throwing and catching `ParseError`, this now just uses `return null` internally.