### PR TITLE
Disable heading levels 4-6

### DIFF
--- a/packages/steamdown/__tests__/__snapshots__/parser.test.ts.snap
+++ b/packages/steamdown/__tests__/__snapshots__/parser.test.ts.snap
@@ -1130,34 +1130,31 @@ exports[`parser > parse() > tree > 'heading' 1`] = `
       "type": "heading",
     },
     {
-      "level": 4,
       "nodes": [
         {
-          "text": "Heading 4",
+          "text": "#### Heading 4",
           "type": "text",
         },
       ],
-      "type": "heading",
+      "type": "paragraph",
     },
     {
-      "level": 5,
       "nodes": [
         {
-          "text": "Heading 5",
+          "text": "##### Heading 5",
           "type": "text",
         },
       ],
-      "type": "heading",
+      "type": "paragraph",
     },
     {
-      "level": 6,
       "nodes": [
         {
-          "text": "Heading 6",
+          "text": "###### Heading 6",
           "type": "text",
         },
       ],
-      "type": "heading",
+      "type": "paragraph",
     },
   ],
   "type": "root",

--- a/packages/steamdown/__tests__/__snapshots__/steamdown.test.ts.snap
+++ b/packages/steamdown/__tests__/__snapshots__/steamdown.test.ts.snap
@@ -178,11 +178,11 @@ exports[`steamdown > 'heading' 1`] = `
 
 [h3]Heading 3[/h3]
 
-[h4]Heading 4[/h4]
+#### Heading 4
 
-[h5]Heading 5[/h5]
+##### Heading 5
 
-[h6]Heading 6[/h6]"
+###### Heading 6"
 `;
 
 exports[`steamdown > 'horizontal rule' 1`] = `

--- a/packages/steamdown/src/parser/block/heading.ts
+++ b/packages/steamdown/src/parser/block/heading.ts
@@ -8,7 +8,7 @@ import type { Parser } from "../types";
 export const heading = {
   hint: (text: string) => text.startsWith("#"),
   parse: (text: string): [nodes.Heading, remainder: string] | null => {
-    const match = /^(#{1,6})\s(.+)(?:(?:\r?\n){1,2}|$)/.exec(text);
+    const match = /^(#{1,3})\s(.+)(?:(?:\r?\n){1,2}|$)/.exec(text);
 
     if (!match) {
       return null;
@@ -21,7 +21,7 @@ export const heading = {
 
     const node: nodes.Heading = {
       type: "heading",
-      level: match[1].length as 1 | 2 | 3 | 4 | 5 | 6,
+      level: match[1].length as 1 | 2 | 3,
       nodes,
     };
 


### PR DESCRIPTION
Steam seems to only document up to level 3. If `[h4]` and above aren't supported, perhaps just rendering them literally as paragraphs is good enough.