### PR TITLE
fix: narrow supported heading levels

### DIFF
--- a/packages/steamdown/src/nodes.ts
+++ b/packages/steamdown/src/nodes.ts
@@ -73,7 +73,8 @@ export interface CodeBlock extends BaseNode {
  */
 export interface Heading extends BaseNode {
   type: "heading";
-  level: 1 | 2 | 3 | 4 | 5 | 6;
+  // AI Generated: pending human review
+  level: 1 | 2 | 3;
   nodes: Inline[];
 }
 


### PR DESCRIPTION
AI-generated communication: This pull request was prepared with Codex and reviewed by the contributor before submission.

## Summary

- narrow `Heading.level` from `1 | 2 | 3 | 4 | 5 | 6` to the Steam-supported `1 | 2 | 3`
- retain the repository-required AI review marker directly above the changed type
- leave runtime parsing and rendering unchanged

Closes #428.

## Regression evidence

I compiled the same temporary negative type contract against both revisions. It accepts level `3` and marks level `4` with `@ts-expect-error`:

- exact base `811dd846c0f83a4a6b1a78bdbd63379d493f5d79`: failed with `TS2578: Unused @ts-expect-error directive`, proving the public type still accepted level `4`
- fixed head: passed, proving level `4` is rejected while level `3` remains accepted

The temporary probe was removed before commit.

## Validation

- `pnpm run -w build`
- `CI=1 pnpm run -w test` — 6 files, 179 tests passed
- `pnpm run -w format-check`
- `pnpm run -w lint`
- `git diff --check`

## Overlap check

The only open upstream PR is #417, which changes the site package and lockfile. It does not touch `packages/steamdown/src/nodes.ts` or this type contract.